### PR TITLE
Fix session header key and clear URL params

### DIFF
--- a/src/launcher-ui/src/components/account/useSessionVerification.js
+++ b/src/launcher-ui/src/components/account/useSessionVerification.js
@@ -17,7 +17,7 @@ export const useSessionVerification = () => {
       try {
         const response = await fetch('/verify-session', {
           method: 'GET',
-          headers: { sessionID },
+          headers: { sessionid: sessionID },
         });
 
         if (!response.ok) {

--- a/src/launcher-ui/src/pages/AccountPage.js
+++ b/src/launcher-ui/src/pages/AccountPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Layout from '../components/Layout';
 import Cookies from 'js-cookie';
 import AccountDashboard from '../components/account/AccountDashboard';
@@ -66,6 +66,9 @@ export default function AccountPage() {
         setUsername(usernameParam);
         setIsLoggedIn(true);
         setCheckingSession(false);
+
+        // Clear the URL parameters after setting cookies
+        window.history.replaceState({}, document.title, '/account');
         return;
       }
 
@@ -80,7 +83,7 @@ export default function AccountPage() {
       try {
         const res = await fetch('/verify-session', {
           method: 'GET',
-          headers: { sessionID },
+          headers: { sessionid: sessionID },
         });
 
         if (!res.ok) {


### PR DESCRIPTION
Updated the session header key from 'sessionID' to 'sessionid' in API requests to match the expected format. Added logic to clear URL parameters after setting cookies on the AccountPage to improve user experience. Removed unused 'useMemo' import from AccountPage.js.