### PR TITLE
Fix extraction error handling

### DIFF
--- a/src/js/downloadManager.js
+++ b/src/js/downloadManager.js
@@ -9,10 +9,16 @@ const { getLatestGameVersion } = require('./versionChecker');
 
 async function extractZip(zipPath, gameId, event) {
   const extractPath = path.join(buildsmithPath, gameId);
-  await extract(zipPath, { dir: extractPath });
-  fs.unlinkSync(zipPath);
-  event.sender.send('download-complete', gameId);
-  return extractPath;
+  try {
+    await extract(zipPath, { dir: extractPath });
+    fs.unlinkSync(zipPath);
+    event.sender.send('download-complete', gameId);
+    return extractPath;
+  } catch (err) {
+    console.error('Extraction error:', err);
+    event.sender.send('download-error', gameId, err.message);
+    throw err;
+  }
 }
 
 async function downloadGame(event, gameId) {


### PR DESCRIPTION
## Summary
- handle errors in `extractZip` so the caller receives `download-error`

## Testing
- `npx jest` *(fails: 403 Forbidden during package install)*

------
https://chatgpt.com/codex/tasks/task_e_68441d142aac8328ae10b7a988a2905a